### PR TITLE
Technique

### DIFF
--- a/app/Http/Controllers/CdcController.php
+++ b/app/Http/Controllers/CdcController.php
@@ -79,7 +79,14 @@ class CdcController extends Controller
             )->deleteFileAfterSend(true);
 
         } catch (\Exception $e) {
-            return back()->with('error', 'Erreur : ' . $e->getMessage() . ' | Ligne : ' . $e->getLine());
+            Log::error('Erreur génération/téléchargement CDC', [
+                'cdc_id' => $cdc->id,
+                'user_id' => Auth::id(),
+                'error'  => $e->getMessage(),
+                'line'   => $e->getLine(),
+            ]);
+
+            return back()->with('error', 'Une erreur est survenue lors du téléchargement.');
         }
     }
 }

--- a/app/Http/Controllers/CdcController.php
+++ b/app/Http/Controllers/CdcController.php
@@ -53,12 +53,6 @@ class CdcController extends Controller
                 ->with('info', 'Remplissez les données pour générer un nouveau CDC basé sur "' . $form->name . '"');
         }
     }
-    public function store(Request $request)
-    {
-        return redirect()->route('forms.create')
-            ->with('error', 'Veuillez utiliser le formulaire de création pour générer un CDC.');
-    }
-
     public function download(Cdc $cdc)
     {
         $this->authorize('view', $cdc);

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -10,6 +10,7 @@ use App\Services\FormFieldsService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
@@ -25,7 +26,6 @@ class FormController extends Controller
 
         if ($request->filled('search')) {
             $search = Str::lower($request->search);
-
             $query->whereFullText('name', $search);
         }
 
@@ -47,7 +47,6 @@ class FormController extends Controller
         $fieldTypes = FieldType::all();
         $duplicateData = session('duplicate_form', []);
         $prefilledFields = $duplicateData['fields'] ?? [];
-
         $prefillData = [];
 
         return view('forms.create', compact('fieldTypes', 'duplicateData', 'prefilledFields', 'prefillData'));
@@ -186,10 +185,11 @@ class FormController extends Controller
                 }
             }
 
-            $cdc = Cdc::create([
+            Cdc::create([
                 'title' => $validated['titre_projet'],
                 'data' => $cdcData,
                 'form_id' => $form->id,
+                'user_id' => Auth::id(),
             ]);
 
             DB::commit();
@@ -202,15 +202,15 @@ class FormController extends Controller
         } catch (\Exception $e) {
             DB::rollBack();
 
-            \Log::error('Erreur création formulaire/CDC', [
+            Log::error('Erreur création formulaire/CDC', [
                 'user_id' => Auth::id(),
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
+                'error'   => $e->getMessage(),
+                'trace'   => $e->getTraceAsString(),
             ]);
 
             return redirect()->back()
                 ->withInput()
-                ->with('error', 'Erreur lors de la création : ' . $e->getMessage());
+                ->with('error', 'Une erreur est survenue lors de la création.');
         }
     }
 
@@ -314,7 +314,6 @@ class FormController extends Controller
         $dateDebut = Carbon::parse($validated['date_debut'])->locale('fr')->isoFormat('D MMMM YYYY');
         $dateFin = Carbon::parse($validated['date_fin'])->locale('fr')->isoFormat('D MMMM YYYY');
         $periodeRealisation = "Du {$dateDebut} au {$dateFin}";
-
         $horaireTravail = $validated['heure_matin_debut'] . ' — ' . $validated['heure_matin_fin'] .
             ', ' . $validated['heure_aprem_debut'] . ' — ' . $validated['heure_aprem_fin'];
 
@@ -440,16 +439,16 @@ class FormController extends Controller
         } catch (\Exception $e) {
             DB::rollBack();
 
-            \Log::error('Erreur mise à jour formulaire', [
+            Log::error('Erreur mise à jour formulaire', [
                 'form_id' => $form->id,
                 'user_id' => Auth::id(),
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString()
+                'error'   => $e->getMessage(),
+                'trace'   => $e->getTraceAsString(),
             ]);
 
             return redirect()->back()
                 ->withInput()
-                ->with('error', 'Erreur lors de la mise à jour : ' . $e->getMessage());
+                ->with('error', 'Une erreur est survenue lors de la mise à jour.');
         }
     }
 
@@ -466,13 +465,14 @@ class FormController extends Controller
                 ->with('success', "Le formulaire \"{$formName}\" a été supprimé avec succès !");
 
         } catch (\Exception $e) {
-            \Log::error('Erreur suppression formulaire', [
+            Log::error('Erreur suppression formulaire', [
                 'form_id' => $form->id,
-                'error' => $e->getMessage()
+                'user_id' => Auth::id(),
+                'error'   => $e->getMessage(),
             ]);
 
             return redirect()->back()
-                ->with('error', 'Erreur lors de la suppression : ' . $e->getMessage());
+                ->with('error', "Une erreur est survenue lors de la suppression du formulaire \"{$formName}\".");
         }
     }
 }

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -7,6 +7,8 @@ use App\Models\Field;
 use App\Models\FieldType;
 use App\Models\Cdc;
 use App\Services\FormFieldsService;
+use App\Http\Requests\StoreCdcRequest;
+use App\Http\Requests\UpdateCdcRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -52,57 +54,9 @@ class FormController extends Controller
         return view('forms.create', compact('fieldTypes', 'duplicateData', 'prefilledFields', 'prefillData'));
     }
 
-    public function store(Request $request)
+    public function store(StoreCdcRequest $request)
     {
-        $phoneRule = ['required', 'string', 'regex:/^\+41\s[0-9]{2}\s[0-9]{3}\s[0-9]{2}\s[0-9]{2}$/'];
-        $validated = $request->validate([
-            'candidat_nom' => 'required|string|max:255',
-            'candidat_prenom' => 'required|string|max:255',
-            'lieu_travail' => 'required|string|max:255',
-            'orientation' => 'nullable|string',
-
-            'chef_projet_nom' => 'required|string|max:255',
-            'chef_projet_prenom' => 'required|string|max:255',
-            'chef_projet_email' => 'required|email',
-            'chef_projet_telephone' => $phoneRule,
-
-            'expert1_nom' => 'required|string|max:255',
-            'expert1_prenom' => 'required|string|max:255',
-            'expert1_email' => 'required|email',
-            'expert1_telephone' => $phoneRule,
-
-            'expert2_nom' => 'required|string|max:255',
-            'expert2_prenom' => 'required|string|max:255',
-            'expert2_email' => 'required|email',
-            'expert2_telephone' => $phoneRule,
-
-            'date_debut' => 'required|date',
-            'date_fin' => 'required|date|after_or_equal:date_debut',
-            'heure_matin_debut' => 'required|date_format:H:i',
-            'heure_matin_fin' => 'required|date_format:H:i',
-            'heure_aprem_debut' => 'required|date_format:H:i',
-            'heure_aprem_fin' => 'required|date_format:H:i',
-            'nombre_heures' => 'required|integer|min:1|max:90',
-
-            'planning_analyse' => 'nullable|string',
-            'planning_implementation' => 'nullable|string',
-            'planning_tests' => 'nullable|string',
-            'planning_documentation' => 'nullable|string',
-
-            'procedure' => 'nullable|string|max:5000',
-
-            'titre_projet' => 'required|string',
-            'materiel_logiciel' => 'nullable|string',
-            'prerequis' => 'nullable|string',
-            'descriptif_projet' => 'required|string',
-            'livrables' => 'nullable|string',
-
-            'fields' => 'nullable|array',
-            'fields.*.name' => 'required_with:fields|string|max:255',
-            'fields.*.label' => 'required_with:fields|string|max:255',
-            'fields.*.field_type_id' => 'required_with:fields|exists:field_types,id',
-            'fields.*.value' => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         $dateDebut = Carbon::parse($validated['date_debut'])->locale('fr')->isoFormat('D MMMM YYYY');
         $dateFin = Carbon::parse($validated['date_fin'])->locale('fr')->isoFormat('D MMMM YYYY');
@@ -118,50 +72,7 @@ class FormController extends Controller
                 'user_id' => Auth::id(),
             ]);
 
-            $cdcData = [
-                'candidat_nom' => $validated['candidat_nom'],
-                'candidat_prenom' => $validated['candidat_prenom'],
-                'lieu_travail' => $validated['lieu_travail'],
-                'orientation' => $validated['orientation'] ?? null,
-
-                'chef_projet_nom' => $validated['chef_projet_nom'],
-                'chef_projet_prenom' => $validated['chef_projet_prenom'],
-                'chef_projet_email' => $validated['chef_projet_email'],
-                'chef_projet_telephone' => $validated['chef_projet_telephone'],
-
-                'expert1_nom' => $validated['expert1_nom'],
-                'expert1_prenom' => $validated['expert1_prenom'],
-                'expert1_email' => $validated['expert1_email'],
-                'expert1_telephone' => $validated['expert1_telephone'],
-
-                'expert2_nom' => $validated['expert2_nom'],
-                'expert2_prenom' => $validated['expert2_prenom'],
-                'expert2_email' => $validated['expert2_email'],
-                'expert2_telephone' => $validated['expert2_telephone'],
-
-                'periode_realisation' => $periodeRealisation,
-                'horaire_travail' => $horaireTravail,
-                'nombre_heures' => $validated['nombre_heures'],
-
-                'date_debut' => $validated['date_debut'],
-                'date_fin' => $validated['date_fin'],
-                'heure_matin_debut' => $validated['heure_matin_debut'],
-                'heure_matin_fin' => $validated['heure_matin_fin'],
-                'heure_aprem_debut' => $validated['heure_aprem_debut'],
-                'heure_aprem_fin' => $validated['heure_aprem_fin'],
-
-                'procedure' => $validated['procedure'] ?? '',
-                'planning_analyse' => $validated['planning_analyse'] ?? '',
-                'planning_implementation' => $validated['planning_implementation'] ?? '',
-                'planning_tests' => $validated['planning_tests'] ?? '',
-                'planning_documentation' => $validated['planning_documentation'] ?? '',
-
-                'titre_projet' => $validated['titre_projet'],
-                'materiel_logiciel' => $validated['materiel_logiciel'] ?? '',
-                'prerequis' => $validated['prerequis'] ?? '',
-                'descriptif_projet' => $validated['descriptif_projet'],
-                'livrables' => $validated['livrables'] ?? '',
-            ];
+            $cdcData = $this->buildCdcData($validated, $periodeRealisation, $horaireTravail);
 
             $orderIndex = 0;
             if (isset($validated['fields']) && count($validated['fields']) > 0) {
@@ -247,69 +158,11 @@ class FormController extends Controller
         return view('forms.edit', compact('form', 'fieldTypes', 'prefillData'));
     }
 
-    public function update(Request $request, Form $form)
+    public function update(UpdateCdcRequest $request, Form $form)
     {
         $this->authorize('update', $form);
-        $phoneRule = ['required', 'string', 'regex:/^\+41\s[0-9]{2}\s[0-9]{3}\s[0-9]{2}\s[0-9]{2}$/'];
 
-        $validated = $request->validate([
-            'candidat_nom' => 'required|string|max:255',
-            'candidat_prenom' => 'required|string|max:255',
-            'lieu_travail' => 'required|string|max:255',
-            'orientation' => 'nullable|string',
-
-            'chef_projet_nom' => 'required|string|max:255',
-            'chef_projet_prenom' => 'required|string|max:255',
-            'chef_projet_email' => 'required|email',
-            'chef_projet_telephone' => $phoneRule,
-
-            'expert1_nom' => 'required|string|max:255',
-            'expert1_prenom' => 'required|string|max:255',
-            'expert1_email' => 'required|email',
-            'expert1_telephone' => $phoneRule,
-
-            'expert2_nom' => 'required|string|max:255',
-            'expert2_prenom' => 'required|string|max:255',
-            'expert2_email' => 'required|email',
-            'expert2_telephone' => $phoneRule,
-
-            'procedure' => 'nullable|string|max:5000',
-
-            'date_debut' => 'required|date',
-            'date_fin' => 'required|date|after_or_equal:date_debut',
-            'heure_matin_debut' => 'required|date_format:H:i',
-            'heure_matin_fin' => 'required|date_format:H:i',
-            'heure_aprem_debut' => 'required|date_format:H:i',
-            'heure_aprem_fin' => 'required|date_format:H:i',
-
-            'nombre_heures' => 'required|integer|min:1|max:90',
-
-            'planning_analyse' => 'nullable|string',
-            'planning_implementation' => 'nullable|string',
-            'planning_tests' => 'nullable|string',
-            'planning_documentation' => 'nullable|string',
-
-            'titre_projet' => 'required|string',
-            'materiel_logiciel' => 'nullable|string',
-            'prerequis' => 'nullable|string',
-            'descriptif_projet' => 'required|string',
-            'livrables' => 'nullable|string',
-
-            'fields' => 'nullable|array',
-            'fields.*.id' => 'nullable|exists:fields,id',
-            'fields.*.name' => 'required_with:fields|string|max:255',
-            'fields.*.label' => 'required_with:fields|string|max:255',
-            'fields.*.value' => 'nullable|string',
-
-            'new_fields' => 'nullable|array',
-            'new_fields.*.name' => 'required_with:new_fields|string|max:255',
-            'new_fields.*.label' => 'required_with:new_fields|string|max:255',
-            'new_fields.*.value' => 'nullable|string',
-            'new_fields.*.field_type_id' => 'required_with:new_fields|exists:field_types,id',
-
-            'deleted_fields' => 'nullable|array',
-            'deleted_fields.*' => 'exists:fields,id',
-        ]);
+        $validated = $request->validated();
 
         $dateDebut = Carbon::parse($validated['date_debut'])->locale('fr')->isoFormat('D MMMM YYYY');
         $dateFin = Carbon::parse($validated['date_fin'])->locale('fr')->isoFormat('D MMMM YYYY');
@@ -324,50 +177,7 @@ class FormController extends Controller
                 'name' => $validated['titre_projet'],
             ]);
 
-            $cdcData = [
-                'candidat_nom' => $validated['candidat_nom'],
-                'candidat_prenom' => $validated['candidat_prenom'],
-                'lieu_travail' => $validated['lieu_travail'],
-                'orientation' => $validated['orientation'] ?? null,
-
-                'chef_projet_nom' => $validated['chef_projet_nom'],
-                'chef_projet_prenom' => $validated['chef_projet_prenom'],
-                'chef_projet_email' => $validated['chef_projet_email'],
-                'chef_projet_telephone' => $validated['chef_projet_telephone'],
-
-                'expert1_nom' => $validated['expert1_nom'],
-                'expert1_prenom' => $validated['expert1_prenom'],
-                'expert1_email' => $validated['expert1_email'],
-                'expert1_telephone' => $validated['expert1_telephone'],
-
-                'expert2_nom' => $validated['expert2_nom'],
-                'expert2_prenom' => $validated['expert2_prenom'],
-                'expert2_email' => $validated['expert2_email'],
-                'expert2_telephone' => $validated['expert2_telephone'],
-
-                'periode_realisation' => $periodeRealisation,
-                'horaire_travail' => $horaireTravail,
-                'nombre_heures' => $validated['nombre_heures'],
-
-                'date_debut' => $validated['date_debut'],
-                'date_fin' => $validated['date_fin'],
-                'heure_matin_debut' => $validated['heure_matin_debut'],
-                'heure_matin_fin' => $validated['heure_matin_fin'],
-                'heure_aprem_debut' => $validated['heure_aprem_debut'],
-                'heure_aprem_fin' => $validated['heure_aprem_fin'],
-
-                'planning_analyse' => $validated['planning_analyse'] ?? '',
-                'planning_implementation' => $validated['planning_implementation'] ?? '',
-                'planning_tests' => $validated['planning_tests'] ?? '',
-                'planning_documentation' => $validated['planning_documentation'] ?? '',
-
-                'procedure' => $validated['procedure'] ?? '',
-                'titre_projet' => $validated['titre_projet'],
-                'materiel_logiciel' => $validated['materiel_logiciel'] ?? '',
-                'prerequis' => $validated['prerequis'] ?? '',
-                'descriptif_projet' => $validated['descriptif_projet'],
-                'livrables' => $validated['livrables'] ?? '',
-            ];
+            $cdcData = $this->buildCdcData($validated, $periodeRealisation, $horaireTravail);
 
             if (isset($validated['fields'])) {
                 foreach ($validated['fields'] as $fieldData) {
@@ -474,5 +284,52 @@ class FormController extends Controller
             return redirect()->back()
                 ->with('error', "Une erreur est survenue lors de la suppression du formulaire \"{$formName}\".");
         }
+    }
+    private function buildCdcData(array $validated, string $periodeRealisation, string $horaireTravail): array
+    {
+        return [
+            'candidat_nom' => $validated['candidat_nom'],
+            'candidat_prenom' => $validated['candidat_prenom'],
+            'lieu_travail' => $validated['lieu_travail'],
+            'orientation' => $validated['orientation'] ?? null,
+
+            'chef_projet_nom' => $validated['chef_projet_nom'],
+            'chef_projet_prenom' => $validated['chef_projet_prenom'],
+            'chef_projet_email' => $validated['chef_projet_email'],
+            'chef_projet_telephone' => $validated['chef_projet_telephone'],
+
+            'expert1_nom' => $validated['expert1_nom'],
+            'expert1_prenom' => $validated['expert1_prenom'],
+            'expert1_email' => $validated['expert1_email'],
+            'expert1_telephone' => $validated['expert1_telephone'],
+
+            'expert2_nom' => $validated['expert2_nom'],
+            'expert2_prenom' => $validated['expert2_prenom'],
+            'expert2_email' => $validated['expert2_email'],
+            'expert2_telephone' => $validated['expert2_telephone'],
+
+            'periode_realisation' => $periodeRealisation,
+            'horaire_travail' => $horaireTravail,
+            'nombre_heures' => $validated['nombre_heures'],
+
+            'date_debut' => $validated['date_debut'],
+            'date_fin' => $validated['date_fin'],
+            'heure_matin_debut' => $validated['heure_matin_debut'],
+            'heure_matin_fin' => $validated['heure_matin_fin'],
+            'heure_aprem_debut' => $validated['heure_aprem_debut'],
+            'heure_aprem_fin' => $validated['heure_aprem_fin'],
+
+            'procedure' => $validated['procedure'] ?? '',
+            'planning_analyse' => $validated['planning_analyse'] ?? '',
+            'planning_implementation' => $validated['planning_implementation'] ?? '',
+            'planning_tests' => $validated['planning_tests'] ?? '',
+            'planning_documentation' => $validated['planning_documentation'] ?? '',
+
+            'titre_projet' => $validated['titre_projet'],
+            'materiel_logiciel' => $validated['materiel_logiciel'] ?? '',
+            'prerequis' => $validated['prerequis'] ?? '',
+            'descriptif_projet' => $validated['descriptif_projet'],
+            'livrables' => $validated['livrables'] ?? '',
+        ];
     }
 }

--- a/app/Http/Requests/StoreCdcRequest.php
+++ b/app/Http/Requests/StoreCdcRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCdcRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $phoneRule = ['required', 'string', 'regex:/^\+41\s[0-9]{2}\s[0-9]{3}\s[0-9]{2}\s[0-9]{2}$/'];
+
+        return [
+            'candidat_nom' => 'required|string|max:255',
+            'candidat_prenom' => 'required|string|max:255',
+            'lieu_travail' => 'required|string|max:255',
+            'orientation' => 'nullable|string',
+
+            'chef_projet_nom' => 'required|string|max:255',
+            'chef_projet_prenom' => 'required|string|max:255',
+            'chef_projet_email' => 'required|email',
+            'chef_projet_telephone' => $phoneRule,
+
+            'expert1_nom' => 'required|string|max:255',
+            'expert1_prenom' => 'required|string|max:255',
+            'expert1_email' => 'required|email',
+            'expert1_telephone' => $phoneRule,
+
+            'expert2_nom' => 'required|string|max:255',
+            'expert2_prenom' => 'required|string|max:255',
+            'expert2_email' => 'required|email',
+            'expert2_telephone' => $phoneRule,
+
+            'date_debut' => 'required|date',
+            'date_fin' => 'required|date|after_or_equal:date_debut',
+            'heure_matin_debut' => 'required|date_format:H:i',
+            'heure_matin_fin' => 'required|date_format:H:i',
+            'heure_aprem_debut' => 'required|date_format:H:i',
+            'heure_aprem_fin' => 'required|date_format:H:i',
+            'nombre_heures' => 'required|integer|min:1|max:90',
+
+            'planning_analyse' => 'nullable|string',
+            'planning_implementation' => 'nullable|string',
+            'planning_tests' => 'nullable|string',
+            'planning_documentation' => 'nullable|string',
+
+            'procedure' => 'nullable|string|max:5000',
+
+            'titre_projet' => 'required|string',
+            'materiel_logiciel' => 'nullable|string',
+            'prerequis' => 'nullable|string',
+            'descriptif_projet' => 'required|string',
+            'livrables' => 'nullable|string',
+
+            'fields' => 'nullable|array',
+            'fields.*.name' => 'required_with:fields|string|max:255',
+            'fields.*.label' => 'required_with:fields|string|max:255',
+            'fields.*.field_type_id' => 'required_with:fields|exists:field_types,id',
+            'fields.*.value' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCdcRequest.php
+++ b/app/Http/Requests/UpdateCdcRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCdcRequest extends StoreCdcRequest
+{
+    public function rules(): array
+    {
+        $baseRules = parent::rules();
+
+        return array_merge($baseRules, [
+            'fields' => 'nullable|array',
+            'fields.*.id' => 'nullable|exists:fields,id',
+            'fields.*.name' => 'required_with:fields|string|max:255',
+            'fields.*.label' => 'required_with:fields|string|max:255',
+            'fields.*.value' => 'nullable|string',
+
+            'new_fields' => 'nullable|array',
+            'new_fields.*.name' => 'required_with:new_fields|string|max:255',
+            'new_fields.*.label' => 'required_with:new_fields|string|max:255',
+            'new_fields.*.value' => 'nullable|string',
+            'new_fields.*.field_type_id' => 'required_with:new_fields|exists:field_types,id',
+            'deleted_fields' => 'nullable|array',
+            'deleted_fields.*' => 'exists:fields,id',
+        ]);
+    }
+}

--- a/app/Services/CdcPhpWordGenerator.php
+++ b/app/Services/CdcPhpWordGenerator.php
@@ -715,17 +715,10 @@ class CdcPhpWordGenerator
 
     private function addPointsTechniques(Cdc $cdc)
     {
-        $customFields = collect($cdc->data)->filter(function($value, $key) {
-            return !in_array($key, [
-                    'candidat_nom', 'candidat_prenom', 'lieu_travail', 'orientation',
-                    'chef_projet_nom', 'chef_projet_prenom', 'chef_projet_email', 'chef_projet_telephone',
-                    'expert1_nom', 'expert1_prenom', 'expert1_email', 'expert1_telephone',
-                    'expert2_nom', 'expert2_prenom', 'expert2_email', 'expert2_telephone',
-                    'periode_realisation', 'horaire_travail', 'nombre_heures',
-                    'planning_analyse', 'planning_implementation', 'planning_tests', 'planning_documentation',
-                    'procedure', 'titre_projet', 'materiel_logiciel', 'prerequis', 'descriptif_projet', 'livrables',
-                    'date_debut', 'date_fin', 'heure_matin_debut', 'heure_matin_fin', 'heure_aprem_debut', 'heure_aprem_fin'
-                ]) && !empty($value);
+        $standardFields = FormFieldsService::getStandardFields();
+
+        $customFields = collect($cdc->data)->filter(function($value, $key) use ($standardFields) {
+            return !in_array($key, $standardFields) && !empty($value);
         });
 
         if ($customFields->count() > 0) {
@@ -762,7 +755,6 @@ class CdcPhpWordGenerator
             $this->addSectionSeparator();
         }
     }
-
     private function addValidation()
     {
         $this->addSectionTitle('9 VALIDATION');

--- a/app/Services/FormFieldsService.php
+++ b/app/Services/FormFieldsService.php
@@ -1,13 +1,9 @@
 <?php
 
-
 namespace App\Services;
 
 class FormFieldsService
 {
-    /**
-     * Champs standards qui ne doivent PAS être stockés dans la table fields
-     */
     private static array $standardFields = [
         'candidat_nom', 'candidat_prenom', 'lieu_travail', 'orientation',
         'chef_projet_nom', 'chef_projet_prenom', 'chef_projet_email', 'chef_projet_telephone',
@@ -19,6 +15,10 @@ class FormFieldsService
         'planning_tests', 'planning_documentation', 'procedure', 'titre_projet',
         'materiel_logiciel', 'prerequis', 'descriptif_projet', 'livrables',
     ];
+    public static function getStandardFields(): array
+    {
+        return self::$standardFields;
+    }
 
     public static function isStandardField(string $fieldName): bool
     {

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,20 +16,12 @@ Route::middleware(['auth'])->group(function () {
         return view('dashboard');
     })->name('dashboard');
 
-    // ROUTES PROTÉGÉES : L'utilisateur doit être vérifié pour accéder à ces fonctionnalités
     Route::middleware(['verified'])->group(function () {
-
-        // Routes CDC
         Route::prefix('cdcs')->name('cdcs.')->group(function () {
             Route::get('/create', [CdcController::class, 'create'])->name('create');
-            Route::post('/', [CdcController::class, 'store'])->name('store');
             Route::get('/{cdc}/download', [CdcController::class, 'download'])->name('download');
         });
-
-        // Routes formulaires
         Route::resource('forms', FormController::class);
-
-        // Routes profil
         Route::prefix('profile')->name('profile.')->group(function () {
             Route::get('/', [ProfileController::class, 'edit'])->name('edit');
             Route::patch('/', [ProfileController::class, 'update'])->name('update');
@@ -42,10 +34,6 @@ Route::middleware(['auth'])->group(function () {
         ->name('admin.')
         ->group(function () {
             Route::resource('users', UserController::class);
-
-            Route::post('users/{user}/roles', [UserController::class, 'updateRoles'])
-                ->name('users.roles.update');
-
             Route::post('users/{user}/verify', [UserController::class, 'verifyEmail'])
                 ->name('users.verify');
         });


### PR DESCRIPTION
#148 
J'ai modifié le code pour logger les erreurs complètes en interne et ne retourner qu'un message générique à l'utilisateur aussi lors du télechargemnt des cdc

#150
Refactoring des contrôleurs via des services et des Form Requests

#151
J'ai centralisé la liste des champs dans un seul endroit : FormFieldsService. CdcPhpWordGenerator

#152 
J'ai nettoyé le contrôleur en supprimant les méthodes inutilisées