### PR TITLE
Update roles

### DIFF
--- a/app/Helpers/RoleHelper.php
+++ b/app/Helpers/RoleHelper.php
@@ -2,11 +2,10 @@
 
 namespace App\Helpers;
 
-use App\Models\User;
-
 class RoleHelper
 {
     public const ROLE_SUPER_ADMIN = 'super-admin';
+
     public const ROLE_USER = 'user';
 
     public static function getAvailableRoles(): array
@@ -17,19 +16,9 @@ class RoleHelper
         ];
     }
 
-    public static function hasRole(User $user, string $role): bool
-    {
-        return $user->hasRole($role);
-    }
-
-    public static function getPrimaryRole(User $user): ?string
-    {
-        return $user->getRoleNames()->first();
-    }
-
     public static function getRoleBadgeColor(?string $role): string
     {
-        return match($role) {
+        return match ($role) {
             self::ROLE_SUPER_ADMIN => 'red',
             self::ROLE_USER => 'green',
             default => 'gray'
@@ -38,7 +27,7 @@ class RoleHelper
 
     public static function getRoleLabel(?string $role): string
     {
-        return match($role) {
+        return match ($role) {
             self::ROLE_SUPER_ADMIN => 'Super Administrateur',
             self::ROLE_USER => 'Utilisateur',
             default => ucfirst((string) $role)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,19 +2,17 @@
 
 namespace App\Models;
 
+use App\Helpers\RoleHelper;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\Form;
-
-
 
 class User extends Authenticatable implements MustVerifyEmail
 {
-    use HasFactory, Notifiable, HasRoles;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -60,4 +58,8 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(Cdc::class);
     }
 
+    public function isSuperAdmin(): bool
+    {
+        return $this->hasRole(RoleHelper::ROLE_SUPER_ADMIN);
+    }
 }

--- a/app/Policies/CdcPolicy.php
+++ b/app/Policies/CdcPolicy.php
@@ -8,10 +8,6 @@ use App\Models\User;
 
 class CdcPolicy
 {
-    public function before(User $user, string $ability): ?bool
-    {
-        return $user->hasRole(RoleHelper::ROLE_SUPER_ADMIN) ? true : null;
-    }
     public function view(User $user, Cdc $cdc): bool
     {
         return $cdc->form->user_id === $user->id;

--- a/app/Policies/CdcPolicy.php
+++ b/app/Policies/CdcPolicy.php
@@ -2,11 +2,16 @@
 
 namespace App\Policies;
 
+use App\Helpers\RoleHelper;
 use App\Models\Cdc;
 use App\Models\User;
 
 class CdcPolicy
 {
+    public function before(User $user, string $ability): ?bool
+    {
+        return $user->hasRole(RoleHelper::ROLE_SUPER_ADMIN) ? true : null;
+    }
     public function view(User $user, Cdc $cdc): bool
     {
         return $cdc->form->user_id === $user->id;

--- a/app/Policies/FormPolicy.php
+++ b/app/Policies/FormPolicy.php
@@ -8,11 +8,6 @@ use App\Models\User;
 
 class FormPolicy
 {
-    public function before(User $user, string $ability): ?bool
-    {
-        return $user->hasRole(RoleHelper::ROLE_SUPER_ADMIN) ? true : null;
-    }
-
     public function view(User $user, Form $form): bool
     {
         return $user->id === $form->user_id;

--- a/app/Policies/FormPolicy.php
+++ b/app/Policies/FormPolicy.php
@@ -2,11 +2,17 @@
 
 namespace App\Policies;
 
+use App\Helpers\RoleHelper;
 use App\Models\Form;
 use App\Models\User;
 
 class FormPolicy
 {
+    public function before(User $user, string $ability): ?bool
+    {
+        return $user->hasRole(RoleHelper::ROLE_SUPER_ADMIN) ? true : null;
+    }
+
     public function view(User $user, Form $form): bool
     {
         return $user->id === $form->user_id;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    protected $policies = [
+        //
+    ];
+
+    public function boot(): void
+    {
+        Gate::before(function (User $user) {
+            if ($user->isSuperAdmin()) {
+                return true;
+            }
+        });
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];


### PR DESCRIPTION
#153 

J'ai supprimé les helpers redondants

RoleHelper a hasRole() et getPrimaryRole() qui faisaient juste wrapper les méthodes Spatie 

j'ai supprimé ça et j'utilise directement :

$user->hasRole($role) au lieu de RoleHelper::hasRole()

$user->getRoleNames()->first()  au lieu de RoleHelper::getPrimaryRole()

#154 

J'ai créé AuthServiceProvider avec Gate::before() pour bypasser les policies pour les super-admins, et ajouté isSuperAdmin() au modèle User